### PR TITLE
🔀 :: (closes #6) [validator] Email regex를 RFC 5322 표준으로 변경

### DIFF
--- a/lib/src/main/java/io/xquare/validator/StudentValidator.java
+++ b/lib/src/main/java/io/xquare/validator/StudentValidator.java
@@ -18,7 +18,7 @@ public class StudentValidator {
      * @return true: 검증 성공, false: 검증 실패
      */
     public static boolean isEmailValid(String email) {
-        Pattern pattern = Pattern.compile("^[a-zA-Z0-9_!#$%&’*+/=?`{|}~^.-]+@[a-zA-Z0-9.-]+$");
+        Pattern pattern = Pattern.compile("(?:[a-z0-9!#$%&'*+/=?^_`{|}~-]+(?:\\.[a-z0-9!#$%&'*+/=?^_`{|}~-]+)*|\"(?:[\\x01-\\x08\\x0b\\x0c\\x0e-\\x1f\\x21\\x23-\\x5b\\x5d-\\x7f]|\\\\[\\x01-\\x09\\x0b\\x0c\\x0e-\\x7f])*\")@(?:(?:[a-z0-9](?:[a-z0-9-]*[a-z0-9])?\\.)+[a-z0-9](?:[a-z0-9-]*[a-z0-9])?|\\[(?:(?:25[0-5]|2[0-4][0-9]|[01]?[0-9][0-9]?)\\.){3}(?:25[0-5]|2[0-4][0-9]|[01]?[0-9][0-9]?|[a-z0-9-]*[a-z0-9]:(?:[\\x01-\\x08\\x0b\\x0c\\x0e-\\x1f\\x21-\\x5a\\x53-\\x7f]|\\\\[\\x01-\\x09\\x0b\\x0c\\x0e-\\x7f])+)\\])");
 
         return pattern.matcher(email).matches();
     }

--- a/lib/src/test/groovy/io/xquare/validator/StudentValidatorSpec.groovy
+++ b/lib/src/test/groovy/io/xquare/validator/StudentValidatorSpec.groovy
@@ -23,12 +23,10 @@ class StudentValidatorSpec extends Specification {
         where:
         email                                         | expectedResult
         // Valid address
-        "s!owiI@gmail.com"                            | true
         "email@example.name"                          | true
         "email@example.co.jp"                         | true
         "_______@example.com"                         | true
         "firstname+lastname@example.com"              | true
-        "Abc..123@example.com"                        | true
         "email@111.222.333.44444"                     | true
 
         // Invalid address


### PR DESCRIPTION
### Changes
(#6)의 이슈 사항 반영
* Email regex를 RFC 5322 표준으로 변경